### PR TITLE
Use https for downloading dependencies from Maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ mapper.writeValue(new File("out.json"), node);
         </snapshots>
         <id>bintray-adjohnson916-maven</id>
         <name>bintray-adjohnson916-maven</name>
-        <url>http://dl.bintray.com/adjohnson916/maven</url>
+        <url>https://dl.bintray.com/adjohnson916/maven</url>
     </repository>
 </repositories>
 


### PR DESCRIPTION
It's a security issue to use http. See http://blog.ontoillogical.com/blog/2014/07/28/how-to-take-over-any-java-developer/